### PR TITLE
certstore_darwin: fix deprecation warnings

### DIFF
--- a/.github/workflows/test-macos-recent-go-versions.yml
+++ b/.github/workflows/test-macos-recent-go-versions.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ["1.20", "1.21", "1.x"]
+        go-version: ["1.26", "1.25"]
         # Doesn't work on Linux.
         os: [macos-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-windows-recent-go-versions.yml
+++ b/.github/workflows/test-windows-recent-go-versions.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ["1.20", "1.21", "1.x"]
+        go-version: ["1.26", "1.25"]
         # Doesn't work on Linux.
         os: [windows-latest]
     runs-on: ${{ matrix.os }}

--- a/certstore_darwin.go
+++ b/certstore_darwin.go
@@ -155,24 +155,31 @@ func (i *macIdentity) CertificateChain() ([]*x509.Certificate, error) {
 	policy := C.SecPolicyCreateSSL(0, nilCFStringRef)
 
 	var trustRef C.SecTrustRef
-	if err := osStatusError(C.SecTrustCreateWithCertificates(C.CFTypeRef(certRef), C.CFTypeRef(policy), &trustRef)); err != nil {
+	osStatusResult := C.SecTrustCreateWithCertificates(C.CFTypeRef(certRef), C.CFTypeRef(policy), &trustRef)
+	if err := osStatusError(osStatusResult); err != nil {
 		return nil, err
 	}
 	defer C.CFRelease(C.CFTypeRef(trustRef))
 
-	var status C.SecTrustResultType
-	if err := osStatusError(C.SecTrustEvaluate(trustRef, &status)); err != nil {
-		return nil, err
+	// Evaluate trust to populate the certificate chain; ignore the trust
+	// result since we only need the chain structure, not trust validation.
+	var cfTrustErr C.CFErrorRef
+	C.SecTrustEvaluateWithError(trustRef, &cfTrustErr)
+	if cfTrustErr != nilCFErrorRef {
+		// ignore the error since we only care about the chain, not trust validation.
 	}
 
-	var (
-		nchain = C.SecTrustGetCertificateCount(trustRef)
-		chain  = make([]*x509.Certificate, 0, int(nchain))
-	)
+	certChain := C.SecTrustCopyCertificateChain(trustRef)
+	if certChain == nilCFArrayRef {
+		return nil, errors.New("error getting certificate chain")
+	}
+	defer C.CFRelease(C.CFTypeRef(certChain))
 
-	for i := C.CFIndex(0); i < nchain; i++ {
-		// TODO: do we need to release these?
-		chainCertref := C.SecTrustGetCertificateAtIndex(trustRef, i)
+	nchain := C.CFArrayGetCount(certChain)
+	chain := make([]*x509.Certificate, 0, int(nchain))
+
+	for j := C.CFIndex(0); j < nchain; j++ {
+		chainCertref := C.SecCertificateRef(C.CFArrayGetValueAtIndex(certChain, j))
 		if chainCertref == nilSecCertificateRef {
 			return nil, errors.New("nil certificate in chain")
 		}


### PR DESCRIPTION
Corrects a number of deprecation warnings in the darwin code.

This updates the go check to 1.25/1.26 which pins the minimum supported macOS version to 12.0 which corresponds with the macOS version required for those Security framework API changes.